### PR TITLE
Bugfix: TypeError: Cannot read property 'history' of undefined

### DIFF
--- a/themes/minimist/src/html.html
+++ b/themes/minimist/src/html.html
@@ -162,7 +162,7 @@ engine: Underscore
       </section>
 {% } %}
 
-{% if ( r.service.history && r.service.history.length ) { %}
+{% if ( r.service && r.service.history && r.service.history.length ) { %}
       <hr>
       <section id="volunteer">
         <header>


### PR DESCRIPTION
Previously broke when a resume didn't have a service section
