### PR TITLE
Fix #has block helper

### DIFF
--- a/themes/modern/src/modern-html.html
+++ b/themes/modern/src/modern-html.html
@@ -90,9 +90,9 @@
           engine settings, but ((#has 'contact.email')) never will.
         --> }}
         <div id="contact">
-          {{#has r.contact.email}}<div class="email"><a href="mailto:{{{ RAW.contact.email }}}">{{ RAW.contact.email }}</a></div>{{/has}}
-          {{#has r.contact.phone}}<div class="phone">{{ RAW.contact.phone }}</div>{{/has}}
-          {{#has r.contact.website}}<div class="website"><a href="{{{ RAW.contact.website }}}">{{ RAW.contact.website }}</a></div>{{/has}}
+          {{#has 'contact.email'}}<div class="email"><a href="mailto:{{{ RAW.contact.email }}}">{{ RAW.contact.email }}</a></div>{{/has}}
+          {{#has 'contact.phone'}}<div class="phone">{{ RAW.contact.phone }}</div>{{/has}}
+          {{#has 'contact.website'}}<div class="website"><a href="{{{ RAW.contact.website }}}">{{ RAW.contact.website }}</a></div>{{/has}}
         </div>
       </header>
 

--- a/themes/modern/src/modern-pdf.html
+++ b/themes/modern/src/modern-pdf.html
@@ -90,9 +90,9 @@
           engine settings, but ((#has 'contact.email')) never will.
         --> }}
         <div id="contact">
-          {{#has r.contact.email}}<div class="email"><a href="mailto:{{{ RAW.contact.email }}}">{{ RAW.contact.email }}</a></div>{{/has}}
-          {{#has r.contact.phone}}<div class="phone">{{ RAW.contact.phone }}</div>{{/has}}
-          {{#has r.contact.website}}<div class="website"><a href="{{{ RAW.contact.website }}}">{{ RAW.contact.website }}</a></div>{{/has}}
+          {{#has 'contact.email'}}<div class="email"><a href="mailto:{{{ RAW.contact.email }}}">{{ RAW.contact.email }}</a></div>{{/has}}
+          {{#has 'contact.phone'}}<div class="phone">{{ RAW.contact.phone }}</div>{{/has}}
+          {{#has 'contact.website'}}<div class="website"><a href="{{{ RAW.contact.website }}}">{{ RAW.contact.website }}</a></div>{{/has}}
         </div>
       </header>
 


### PR DESCRIPTION
## Background

Contact details are left blank regardless of whether they are specified or not. This is because the `#has` helpers are incorrect. Not sure if always broken or due to a change.

## What does this do?

Modify `{{#has r.foo}}` to `{{#has 'foo'}}`