### PR TITLE
Awesome: Avoid LaTeX error when label is undefined.

### DIFF
--- a/themes/awesome/src/latex/examples/cv.tex
+++ b/themes/awesome/src/latex/examples/cv.tex
@@ -52,7 +52,7 @@
 %	Comment any of the lines below if they are not required
 %-------------------------------------------------------------------------------
 \name{[~ print(h.initialWords( r.name )) ~]}{[[ h.lastWord( r.name ) ]]}
-\position{[[ r.info.label ]]}
+[~ if (r.info.label) { ~]\position{[[ r.info.label ]]}[~ } ~]
 \address{[[ r.location.address ]]}
 
 \mobile{[[ r.contact.phone ]]}


### PR DESCRIPTION
According to the FRESH schema, the `label` property of the `info` object is not required. If a label is not provided, `cv.tex` will containe the command `\position{}`, which will define the macro `\@position` to be empty. When `\makecvheader` is expanded, we will get the following line.
```latex
\headerpositionstyle{\@position\\[\acvHeaderAfterPositionSkip]}
```
This will cause an error. We can sidestep the issue by only calling `\position` if a label (that will evaluate to `true` in the template) is given.
