### PR TITLE
Add meta viewport tag in compact head

### DIFF
--- a/themes/compact/src/compact-html.html
+++ b/themes/compact/src/compact-html.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ RAW.name }}</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     {{{styleSheet "compact-html.css"}}}


### PR DESCRIPTION
See [recommended minimum to put in `<head>`](https://github.com/joshbuchea/HEAD#recommended-minimum).

Without this tag, the resume looks "bad" on mobile (browser emulation looks file, but on actual devices it looks bad). I've only added the tag on compact as that is the one I'm using (and have tested). If you want me to add it other themes, I can do that too.