### PR TITLE
Awesome: allow undefined speaking highlights.

### DIFF
--- a/themes/awesome/src/latex/examples/cv/presentation.tex
+++ b/themes/awesome/src/latex/examples/cv/presentation.tex
@@ -13,10 +13,10 @@
 %---------------------------------------------------------
   \cventry
     {[[ spk.title ]]} % Role
-    {[[ spk.event ]])} % Event
+    {[[ spk.event ]]} % Event
     {[[ spk.location ]]} % Location
     {[[ h.date(spk.date) ]]} % Date(s)
-    {[~ if (r.speaking && r.speaking.length) { ~]
+    {[[ spk.summary ]][~ if (spk.highlights && spk.highlights.length) { ~]
       \begin{cvitems} % Description(s)
 [[ h.pad( spk.highlights.map( function(h) { return '\\item {' + h + '}' }), -8 ) ]]
       \end{cvitems}

--- a/themes/awesome/src/latex/examples/resume/presentation.tex
+++ b/themes/awesome/src/latex/examples/resume/presentation.tex
@@ -13,10 +13,10 @@
 %---------------------------------------------------------
   \cventry
     {[[ spk.title ]]} % Role
-    {[[ spk.event ]])} % Event
+    {[[ spk.event ]]} % Event
     {[[ spk.location ]]} % Location
     {[[ h.date(spk.date) ]]} % Date(s)
-    {[~ if (r.speaking && r.speaking.length) { ~]
+    {[[ spk.summary ]][~ if (spk.highlights && spk.highlights.length) { ~]
       \begin{cvitems} % Description(s)
 [[ h.pad( spk.highlights.map( function(h) { return '\\item {' + h + '}' }), -8 ) ]]
       \end{cvitems}


### PR DESCRIPTION
Suppose a file `test.json` contains the following.
```json
{
	"name": "Julia Child",

	"meta": {
		"format": "FRESH@0.1.0"
	},

	"info": {},

	"contact": {},

	"location": {},

	"speaking": [
		{
			"title": "How to Make Pancakes",
			"event": "Pancake Breakfast 2018"
		}
	]
}
```
Building fails due to an assumption that speaking engagements have highlights (not mandated by the FRESH schema).
```console
$ hackmyresume --version

*** HackMyResume v1.8.0 ***
1.8.0
$ hackmyresume VALIDATE test.json 

*** HackMyResume v1.8.0 ***
Validating test.json against the FRESH schema: VALID!
$ hackmyresume BUILD test.json TO test.latex --theme fresh-themes/themes/awesome

*** HackMyResume v1.8.0 ***
Reading FRESH resume: test.json
Applying AWESOME theme (3 formats)
Generating LATEX resume: test.latex
An error occurred during template invocation.
   TypeError: Cannot read property 'map' of undefined
```
This commit fixes the issue.