### PR TITLE
Not Rendering Apostrophe in Some Places

### DIFF
--- a/partials/doc/section/education.hbs
+++ b/partials/doc/section/education.hbs
@@ -68,7 +68,7 @@
         <w:rPr>
           <w:sz-cs w:val="20"/>
         </w:rPr>
-        <w:t>{{ this }}</w:t>
+        <w:t>{{{ this }}}</w:t>
       </w:r>
     </w:p>
     {{/each}}

--- a/partials/doc/section/extracurricular.hbs
+++ b/partials/doc/section/extracurricular.hbs
@@ -15,7 +15,7 @@
         </w:tabs>
       </w:pPr>
       <w:r wsp:rsidR="00C146CA" wsp:rsidRPr="00C146CA">
-        <w:t>{{ title }}, </w:t>
+        <w:t>{{{ title }}}, </w:t>
       </w:r>
       {{#if url}}<w:hlink w:dest="{{{ url }}}">{{/if}}
         <w:r wsp:rsidR="009452CA" wsp:rsidRPr="00606071">

--- a/partials/doc/section/projects.hbs
+++ b/partials/doc/section/projects.hbs
@@ -24,7 +24,7 @@
             <w:rStyle w:val="Hyperlink"/>
           </w:rPr>
           {{/if}}
-          <w:t>{{ title }}</w:t>
+          <w:t>{{{ title }}}</w:t>
         </w:r>
       {{#if url}}</w:hlink>{{/if}}
       <w:r wsp:rsidR="00EA0B64">

--- a/partials/doc/section/recognition.hbs
+++ b/partials/doc/section/recognition.hbs
@@ -21,7 +21,7 @@
             <w:rStyle w:val="Hyperlink"/>
           </w:rPr>
           {{/if}}
-          <w:t>{{ title }}</w:t>
+          <w:t>{{{ title }}}</w:t>
         </w:r>
       {{#if url}}</w:hlink>{{/if}}
       <w:r wsp:rsidR="00EA0B64">

--- a/partials/doc/section/skills.hbs
+++ b/partials/doc/section/skills.hbs
@@ -68,7 +68,7 @@
               <w:caps/>
               <w:spacing w:val="22"/>
             </w:rPr>
-            <w:t>{{#each skills }}{{ this }}{{#unless @last}}  {{/unless}}{{/each}}</w:t>
+            <w:t>{{#each skills }}{{{ this }}}{{#unless @last}}  {{/unless}}{{/each}}</w:t>
           </w:r>
         </w:p>
       </w:tc>

--- a/partials/doc/section/speaking.hbs
+++ b/partials/doc/section/speaking.hbs
@@ -21,7 +21,7 @@
             <w:rStyle w:val="Hyperlink"/>
           </w:rPr>
           {{/if}}
-          <w:t>{{ title }}</w:t>
+          <w:t>{{{ title }}}</w:t>
         </w:r>
       {{#if url}}</w:hlink>{{/if}}
       <w:r wsp:rsidR="00EA0B64">

--- a/partials/html/section/extracurricular.hbs
+++ b/partials/html/section/extracurricular.hbs
@@ -8,7 +8,7 @@
   {{#each r.extracurricular}}
     {{#> body-extracurricular }}
     <div>
-      <h3><em>{{ title }}</em>,
+      <h3><em>{{{ title }}}</em>,
         {{#if url }}
         <a href="{{{ url }}}">{{ activity }}</a>
         {{else}}

--- a/partials/html/section/projects.hbs
+++ b/partials/html/section/projects.hbs
@@ -9,7 +9,7 @@
     <div>
     <h3>{{#if role}}<em>{{camelCase role }}</em>,{{/if}}
     {{#if url}}
-    <a href="{{{ url }}}">{{ title }}</a>
+    <a href="{{{ url }}}">{{{ title }}}</a>
     {{else}}
     {{ title }}
     {{/if}}

--- a/partials/html/section/recognition.hbs
+++ b/partials/html/section/recognition.hbs
@@ -7,7 +7,7 @@
   {{#each r.recognition}}
     {{#> body-recognition }}
     <div>
-    <h3><em>{{ title }}</em>, {{{link from url }}}</h3>
+    <h3><em>{{{ title }}}</em>, {{{link from url }}}</h3>
     <span class="tenure">{{date date 'YYYY' }}</span>
     {{{ summary }}}
     {{> highlights }}

--- a/partials/html/section/samples.hbs
+++ b/partials/html/section/samples.hbs
@@ -9,9 +9,9 @@
     <div>
     <h3>
     {{#if url}}
-    <a href="{{{ url }}}">{{ title }}</a>
+    <a href="{{{ url }}}">{{{ title }}}</a>
     {{else}}
-    {{ title }}
+    {{{ title }}}
     {{/if}}
     </h3>
     <span class="tenure">{{date date 'YYYY-MM'}}</span>

--- a/partials/html/section/testimonials.hbs
+++ b/partials/html/section/testimonials.hbs
@@ -7,7 +7,7 @@
   {{#each r.testimonials}}
     {{#> body-testimonials }}
     <div>
-    <h3><em>{{ name }}</em></h3>
+    <h3><em>{{{ name }}}</em></h3>
     <p>{{{ quote }}}</p>
     </div>
     {{/body-testimonials}}


### PR DESCRIPTION
Figured out the Apostrophe isn't being rendered in various sections, such as recognition.

HTML Escaped "title" in the HTML and Doc sections. Note that before these changes in reading.hbs and writing.hbs, the "title" is already escaped, but not all of the sections which has titles was escaped for some reason.